### PR TITLE
Secrets Manager refresh fixes

### DIFF
--- a/helm/jit/templates/deployment.yaml
+++ b/helm/jit/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             path: /healthz
             port: {{ .Values.env.containerPort | default 5000 }}
             scheme: HTTP
-          initialDelaySeconds: 20
+          initialDelaySeconds: 10
           failureThreshold: 2
           timeoutSeconds: 5
         readinessProbe:
@@ -61,7 +61,7 @@ spec:
             path: /healthz
             port: {{ .Values.env.containerPort | default 5000 }}
             scheme: HTTP
-          initialDelaySeconds: 20
+          initialDelaySeconds: 10
           failureThreshold: 2
           timeoutSeconds: 5
         imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}

--- a/jit-client/client-src/go.mod
+++ b/jit-client/client-src/go.mod
@@ -4,7 +4,7 @@ go 1.23.2
 
 require (
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 )
 
 require golang.org/x/net v0.37.0 // indirect

--- a/jit-client/client-src/go.sum
+++ b/jit-client/client-src/go.sum
@@ -1,11 +1,7 @@
-github.com/go-resty/resty/v2 v2.16.4 h1:81IjtszQKwbz7dot4LLYGwhJNUsNwECD2O7nru5q60E=
-github.com/go-resty/resty/v2 v2.16.4/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
 golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=

--- a/jit-proxy-server/client/constants.py
+++ b/jit-proxy-server/client/constants.py
@@ -62,8 +62,8 @@ class SecretConfig:
             self.ping_token_endpoint = self._ping_dict['auth-server-url']
         if secret_metadata['type'] == 'nuid':
             self._nuid_dict = self.get_secret(secret_metadata['arn'])
-            self.nuid_username = self.nuid_dict['username']
-            self.nuid_password = self.nuid_dict['password']
+            self.nuid_username = self._nuid_dict['username']
+            self.nuid_password = self._nuid_dict['password']
     
     def check_secret_rotation(self):
         for secret in self.secret_metadata:

--- a/jit-proxy-server/client/constants.py
+++ b/jit-proxy-server/client/constants.py
@@ -71,6 +71,9 @@ class SecretConfig:
             if check_rotation_time and check_rotation_time > secret['last_rotated']:
                 logger.info(f"Secret {secret['type']} has been rotated. Refreshing secret data...")
                 self.refresh_secret_data(secret)
+                self.secret_metadata.remove(secret)
+                self.secret_metadata.append({'type':secret['type'], 'arn': secret['arn'], 'last_rotated': check_rotation_time})
+                logger.info(f"Secret metadata for {secret['type']} has been updated.")
 
 
 

--- a/jit-proxy-server/client/constants.py
+++ b/jit-proxy-server/client/constants.py
@@ -1,51 +1,95 @@
-import os,json,boto3,logging,sys
+import os,json,boto3,botocore,logging,sys
 
 aws_sm_client = boto3.client('secretsmanager')
 logger = logging.getLogger('jit_proxy')
+certificate_path = os.environ.get('JIT_CERT_FILE','/etc/config/jit-config/ca.crt')
 
-jit_config_file = os.environ.get('JIT_CONFIG_FILE', '/etc/config/jit-config/jit.json')
+_jit_config_file = os.environ.get('JIT_CONFIG_FILE', '/etc/config/jit-config/jit.json')
 jit_config = {}
+with open(_jit_config_file, 'r') as f:
+   jit_config = json.load(f)
 
-with open(jit_config_file, 'r') as f:
-    jit_config = json.load(f)
-# Retrieve settings
-jit_endpoint = jit_config['jit_endpoint']
-ping_secret_arn = jit_config['ping_secret']
-nuid_secret_arn = jit_config['nuid_secret']
-
-def get_secret_lastrotated(secret_arn):
-    secret_last_rotated = None
-    try:
-        secret_last_rotated = aws_sm_client.describe_secret(secret_arn)['LastRotatedDate']
-    except Exception as e:
-        logger.critical(f"Error retrieving secret metadata {secret_arn}: {e}")
-    return secret_last_rotated
-
-def get_secret(secret_arn):
-    secret_value = None
-    try:
-        secret_str = aws_sm_client.get_secret_string(secret_arn)
-        secret_value = json.loads(secret_str)
-    except Exception as e:
-        logger.critical(f"Error retrieving secret {secret_arn}: {e}")
-    return secret_value
-
-ping_dict = get_secret(ping_secret_arn)
-nuid_dict = get_secret(nuid_secret_arn)
-secret_metadata = [{'type':'ping','arn': ping_secret_arn, 'last_rotated': get_secret_lastrotated(ping_secret_arn)},
-                   {'type':'nuid','arn': nuid_secret_arn, 'last_rotated': get_secret_lastrotated(nuid_secret_arn)}]
-
-client_secret = ping_dict['client-secret']
-client_id = ping_dict['client-id']
-token_endpoint = ping_dict['auth-server-url']
-
-r_username = nuid_dict['username']
-r_password = nuid_dict['password']
+# Module constants. 
 
 access_token_expiry_time = float(jit_config['minimum_token_validity_required_in_seconds'])
 minimum_token_validity_required_in_seconds = int(jit_config['minimum_token_validity_required_in_seconds'])
 fm_projects_attribute = jit_config['prj_attribute_name']
-certificate_path = os.environ.get('JIT_CERT_FILE','/etc/config/jit-config/ca.crt')
 
 def to_debug():
-    return jit_config
+   return jit_config
+
+class SecretConfig:
+
+    def __init__(self,jit_config):
+        # Retrieve settings        
+        self.jit_endpoint = jit_config['jit_endpoint']
+        self._ping_secret_arn = jit_config['ping_secret']
+        self._nuid_secret_arn = jit_config['nuid_secret']        
+        self.secret_metadata = [{'type':'ping','arn': self._ping_secret_arn, 'last_rotated': self._get_secret_lastrotated(self._ping_secret_arn)},
+                            {'type':'nuid','arn': self._nuid_secret_arn, 'last_rotated': self._get_secret_lastrotated(self._nuid_secret_arn)}]
+        self._ping_dict = self.get_secret(self._ping_secret_arn)
+        self._nuid_dict = self.get_secret(self._nuid_secret_arn)
+        self.ping_client_id = self._ping_dict['client-id']
+        self.ping_client_secret = self._ping_dict['client-secret']
+        self.ping_token_endpoint = self._ping_dict['auth-server-url']
+        self.nuid_username = self._nuid_dict['username']
+        self.nuid_password = self._nuid_dict['password']
+
+    def _get_secret_lastrotated(self,secret_arn):
+        secret_last_rotated = None
+        try:
+            secret_metadata = aws_sm_client.describe_secret(SecretId=secret_arn)
+            if 'LastRotatedDate' in secret_metadata:
+                secret_last_rotated = secret_metadata['LastRotatedDate']
+        except botocore.exceptions.ClientError as e:
+            logger.critical(f"Error retrieving secret metadata {secret_arn}: {e.response['Error']['Message']}")
+        return secret_last_rotated
+
+    def get_secret(self,secret_arn):
+        secret_value = None
+        try:
+            secret_str = aws_sm_client.get_secret_value(SecretId=secret_arn)['SecretString']
+            secret_value = json.loads(secret_str)
+        except botocore.exceptions.ClientError as e:
+            logger.critical(f"Error retrieving secret {secret_arn}: {e.response['Error']['Message']}")
+        return secret_value
+
+    def refresh_secret_data(self,secret_metadata):
+        if secret_metadata['type'] == 'ping':
+            self._ping_dict = self.get_secret(secret_metadata['arn'])
+            self.ping_client_id = self._ping_dict['client-id']
+            self.ping_client_secret = self._ping_dict['client-secret']
+            self.ping_token_endpoint = self._ping_dict['auth-server-url']
+        if secret_metadata['type'] == 'nuid':
+            self._nuid_dict = self.get_secret(secret_metadata['arn'])
+            self.nuid_username = self.nuid_dict['username']
+            self.nuid_password = self.nuid_dict['password']
+    
+    def check_secret_rotation(self):
+        for secret in self.secret_metadata:
+            check_rotation_time = self._get_secret_lastrotated(secret['arn'])
+            if check_rotation_time and check_rotation_time > secret['last_rotated']:
+                logger.info(f"Secret {secret['type']} has been rotated. Refreshing secret data...")
+                self.refresh_secret_data(secret)
+
+
+
+
+
+# secret_metadata = [{'type':'ping','arn': ping_secret_arn, 'last_rotated': get_secret_lastrotated(ping_secret_arn)},
+#                    {'type':'nuid','arn': nuid_secret_arn, 'last_rotated': get_secret_lastrotated(nuid_secret_arn)}]
+
+# client_secret = ping_dict['client-secret']
+# client_id = ping_dict['client-id']
+# token_endpoint = ping_dict['auth-server-url']
+
+# r_username = nuid_dict['username']
+# r_password = nuid_dict['password']
+
+# access_token_expiry_time = float(jit_config['minimum_token_validity_required_in_seconds'])
+# minimum_token_validity_required_in_seconds = int(jit_config['minimum_token_validity_required_in_seconds'])
+# fm_projects_attribute = jit_config['prj_attribute_name']
+# certificate_path = os.environ.get('JIT_CERT_FILE','/etc/config/jit-config/ca.crt')
+
+# def to_debug():
+#     return jit_config

--- a/jit-proxy-server/jit_server.py
+++ b/jit-proxy-server/jit_server.py
@@ -24,11 +24,8 @@ def create_app():
     return app
 
 def check_update_jit_client():
-    now = datetime.now()
     global client
-    if client._access_token_expiry_time and client._access_token_expiry_time < now:
-        logger.info("JIT Client OAuth token expired. Refreshing...")
-        client = JitAccessEngineClient()
+    client.refresh_jit_access_token()
 
 def verify_user(user_jwt):
     headers = {
@@ -148,6 +145,8 @@ def jit_groups():
 
 @app.route('/healthz', methods=['GET'])
 def healthz():
+    global client
+    client.refresh_secrets_data()
     return {}
 
 @app.route('/test', methods=['GET'])

--- a/jit-proxy-server/requirements.txt
+++ b/jit-proxy-server/requirements.txt
@@ -2,6 +2,7 @@ flask
 requests
 configparser
 boto3
+botocore
 gunicorn
 PyJWT
 logging

--- a/jit-proxy-server/requirements.txt
+++ b/jit-proxy-server/requirements.txt
@@ -2,8 +2,6 @@ flask
 requests
 configparser
 boto3
-botocore
-aws_secretsmanager_caching
 gunicorn
 PyJWT
 logging


### PR DESCRIPTION
This PR includes changes to the Secrets Manager-related functionality within the JIT Phase 2 work. Rather than the mess of variables and methods that was `constants.py` for the server, we now split things out:

Reading in the config file and loading the constant/static values from the config file are still part of `constants`: but there is a new `SecretConfig` class to handle config parameters that may change during runtime (specifically, AWS Secrets Manager data where secrets may get rotated).