### PR TITLE
JIT Phase 2 Bugfix: JIT project name exact match

### DIFF
--- a/jit-client/client-src/test-jit-client.go
+++ b/jit-client/client-src/test-jit-client.go
@@ -42,15 +42,6 @@ func getJITUserProjects(tokenString string, jitURL string) string {
 	return resp.String()
 }
 
-func testProjectCredentials(tokenString string, projectID string, jitURL string) string {
-	resp, err := reqWithToken(tokenString, jitURL+"/"+projectID)
-	if err != nil {
-		fmt.Printf("Error getting credentials for project %s. Status code: %s, Error %s\n", projectID, resp, err)
-		return resp.String()
-	}
-	return resp.String()
-}
-
 func parseJWT(tokenString string) *jwt.Token {
 	parsedJWT, _, err := jwt.NewParser().ParseUnverified(string(tokenString), make(jwt.MapClaims))
 	if err != nil {
@@ -89,18 +80,6 @@ func main() {
 	fmt.Printf("User JWT contents: \n%v\n", string(pretty_print))
 	fmt.Printf("Gathering User project list from JIT Proxy...\n")
 	user_projects := getJITUserProjects(user, user_projects_endpoint)
-	fmt.Printf("User projects: %s\n", string(user_projects))
-	var project_array []string
-	json.Unmarshal([]byte(user_projects), &project_array)
-	fmt.Printf("Testing project credentials for project list: %s\n", project_array)
-	for _, project := range project_array {
-		project_credential_endpoint := jit_endpoint_base + "/jit_sessions/" + project
-		project_credentials := testProjectCredentials(user, project, project_credential_endpoint)
-		pretty_print, err := json.MarshalIndent(project_credentials, "", "    ")
-		if err != nil {
-			fmt.Printf("Error getting credentials for project %s: %s\n", project, project_credentials)
-		} else {
-			fmt.Printf("Project %s credentials: \n%v\n", project, string(pretty_print))
-		}
-	}
+	fmt.Printf("User projects: %s\n", user_projects)
+
 }

--- a/jit-proxy-server/jit_server.py
+++ b/jit-proxy-server/jit_server.py
@@ -83,7 +83,7 @@ def jit_aws_credentials(project=None,user_jwt=None):
         if project:
            # Note: we must send the group names as lower-cased to the JIT API (and we write them as lower-cased on the client side),
            # but they are present as upper-cased in the user JWT.
-           user[constants.fm_projects_attribute] = [grp_name for grp_name in user[constants.fm_projects_attribute] if project.upper() in grp_name]
+           user[constants.fm_projects_attribute] = [grp_name for grp_name in user[constants.fm_projects_attribute] if project.upper() == grp_name.split("-")[-1]]
         logger.info(f'Fetching Credentials for user: {user["preferred_username"]}')
         session_list = create_new_sessions(user_id=user['preferred_username'],user_mail=user['email'],user_group_list=user[constants.fm_projects_attribute])
         return session_list


### PR DESCRIPTION
This is a bugfix release. Customer found an issue where two JIT groups with similar names would match in the per-project credential refresh calls from the client. This would result in one project's credentials going stale, while the refreshed credentials would get updated in a different project.